### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ccaabrw/918be2cb-11b2-46c7-ab65-39e98f0ec1e3/673ca017-307e-4d73-8921-43a6ce4f90d3/_apis/work/boardbadge/8f3a72a5-39bf-4e24-9bf6-bc587979a1fc)](https://dev.azure.com/ccaabrw/918be2cb-11b2-46c7-ab65-39e98f0ec1e3/_boards/board/t/673ca017-307e-4d73-8921-43a6ce4f90d3/Microsoft.RequirementCategory)
 # Your GitHub Learning Lab Repository for GitHub Pages
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ccaabrw/918be2cb-11b2-46c7-ab65-39e98f0ec1e3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.